### PR TITLE
Do strict type checking when looking up selected notification roles

### DIFF
--- a/fail2wp/fail2wp.php
+++ b/fail2wp/fail2wp.php
@@ -2689,7 +2689,7 @@ class Fail2WP {
         // too, but we're likely to have less configured roles/caps than what
         // is available. So maybe this will save an iteration or two :-)
         foreach( $notify_roles as $role ) {
-            if ( in_array( $role, $roles ) && $roles[$role] ) {
+            if ( in_array( $role, $roles, true ) && array_key_exists( $role, $roles ) ) {
                 return( true );
             }
         }

--- a/fail2wp/fail2wp.php
+++ b/fail2wp/fail2wp.php
@@ -2689,7 +2689,7 @@ class Fail2WP {
         // too, but we're likely to have less configured roles/caps than what
         // is available. So maybe this will save an iteration or two :-)
         foreach( $notify_roles as $role ) {
-            if ( in_array( $role, $roles, true ) && array_key_exists( $role, $roles ) ) {
+            if ( in_array( $role, $roles, true ) && array_key_exists( $role, $roles ) && $roles[$role] ) {
                 return( true );
             }
         }


### PR DESCRIPTION
Because the `$roles` array is an array of boolean values and there's no strict type checking the `in_array()` will always return true, and if the key doesn't exist in `$roles` throws a warning.

This PR improves that by adding strict type checking, and also using `array_key_exists` to check for existance of the key.