### PR TITLE
check that email match field is not empty before running email check on new user registrations

### DIFF
--- a/fail2wp/fail2wp.php
+++ b/fail2wp/fail2wp.php
@@ -1036,7 +1036,7 @@ class Fail2WP {
                 $errors->add( 'fail2wp_username_ban', esc_html__( 'Invalid username, please try again.', 'fail2wp' ) );
             }
         }
-        if ( ! $have_error ) {
+        if ( ! $have_error && ! empty( $this->fail2wp_reguser_useremail_require ) ) {
             $invalid_email = true;
             if ( ! empty ( $user_email ) ) {
                 $invalid_email = true;


### PR DESCRIPTION
This fixes a case where new user registration can become inadvertently disabled if:
- The `Banned usernames` field has a value
- The `Email must match` field is empty

This results in:
- The `fail2wp_admin_check_new_user` filter will be applied at l.422, because of the `Banned usernames` value
- The email match check starting at l.1039 will always be run regardless of the field value, and defaults to invalid
- The email match will always return invalid because there is no value to match against
- New user registrations are then effectively disabled, as all emails are found to be invalid
